### PR TITLE
refactor: 레시피 폼 제출 로직을 별도 함수로 분리

### DIFF
--- a/src/features/create-recipe/create-recipe.lib.ts
+++ b/src/features/create-recipe/create-recipe.lib.ts
@@ -1,0 +1,47 @@
+import { CreateRecipe } from './create-recipe.contract';
+
+/**
+ * 레시피 폼 데이터를 서버에 제출하는 함수입니다.
+ * 현재는 실제 API 호출 대신 Promise를 사용하여 모킹된 응답을 반환합니다.
+ */
+export async function submitRecipeForm(formData: CreateRecipe) {
+  try {
+    const newFormData = structuredClone(formData);
+
+    // 1. 썸네일 이미지 처리
+    if (formData.thumbnail instanceof File) {
+      // 실제 API 호출 대신 Promise 사용
+      newFormData.thumbnail = await new Promise<string>((resolve) => {
+        setTimeout(() => {
+          resolve('https://picsum.photos/id/237/350/200');
+        }, 1000);
+      });
+    }
+
+    // 2. 조리 단계 이미지들 처리
+    const cookingSteps = formData.cookingSteps.map((step) => {
+      if (step.image instanceof File) {
+        return new Promise<string>((resolve) => {
+          setTimeout(() => {
+            resolve('https://picsum.photos/id/237/350/200');
+          }, 1000);
+        });
+      }
+      return null;
+    });
+
+    let index = 0;
+    for await (const step of cookingSteps) {
+      if (step) {
+        newFormData.cookingSteps[index].image = step;
+      }
+      index++;
+    }
+
+    console.log('최종 제출될 데이터:', newFormData);
+    return newFormData;
+  } catch (error) {
+    console.error('레시피 저장 중 오류 발생:', error);
+    throw error;
+  }
+}

--- a/src/features/create-recipe/create-recipe.ui.tsx
+++ b/src/features/create-recipe/create-recipe.ui.tsx
@@ -10,6 +10,7 @@ import { Label } from '@/shared/ui/label';
 import { Textarea } from '@/shared/ui/textarea';
 
 import { CreateRecipe, CreateRecipeSchema } from './create-recipe.contract';
+import { submitRecipeForm } from './create-recipe.lib';
 
 export function CreateRecipeForm() {
   const methods = useForm<CreateRecipe>({
@@ -22,38 +23,8 @@ export function CreateRecipeForm() {
 
   const onSubmit = async (formData: CreateRecipe) => {
     try {
-      const newFormData = structuredClone(formData);
-
-      // 1. 썸네일 이미지 처리
-      if (formData.thumbnail instanceof File) {
-        // 실제 API 호출 대신 Promise 사용
-        newFormData.thumbnail = await new Promise<string>((resolve) => {
-          setTimeout(() => {
-            resolve('https://picsum.photos/id/237/350/200');
-          }, 1000);
-        });
-      }
-
-      // 2. 조리 단계 이미지들 처리
-      const cookingSteps = formData.cookingSteps.map((step) => {
-        if (step.image instanceof File) {
-          return new Promise<string>((resolve) => {
-            setTimeout(() => {
-              resolve('https://picsum.photos/id/237/350/200');
-            }, 1000);
-          });
-        }
-        return null;
-      });
-      let index = 0;
-      for await (const step of cookingSteps) {
-        if (step) {
-          newFormData.cookingSteps[index].image = step;
-        }
-        index++;
-      }
-
-      console.log('최종 제출될 데이터:', newFormData);
+      const newFormData = await submitRecipeForm(formData);
+      console.log('레시피 저장 완료:', newFormData);
     } catch (error) {
       console.error('레시피 저장 중 오류 발생:', error);
     }


### PR DESCRIPTION
- 폼 제출 로직의 복잡성을 낮추기 위해 submitRecipeForm 함수로 분리
- 이미지 업로드 로직을 포함한 폼 제출 처리를 모듈화하여 재사용성 향상